### PR TITLE
Decode JSON into UTF-8 strings

### DIFF
--- a/chaosk8s/__init__.py
+++ b/chaosk8s/__init__.py
@@ -123,16 +123,16 @@ def explore_kubernetes_system() -> DiscoveredSystemInfo:
     v1ext = client.ExtensionsV1beta1Api(api)
 
     ret = v1core.list_namespace(_preload_content=False)
-    namespaces = ret.read()
+    namespaces = ret.read().decode('utf-8')
 
     info = {}
     for ns in json.loads(namespaces)["items"]:
         ret = v1core.list_namespaced_pod(
             namespace=ns["metadata"]["name"], _preload_content=False)
-        info["pods"] = json.loads(ret.read())
+        info["pods"] = json.loads(ret.read().decode('utf-8'))
 
         ret = v1ext.list_namespaced_deployment(
             namespace=ns["metadata"]["name"], _preload_content=False)
-        info["deployments"] = json.loads(ret.read())
+        info["deployments"] = json.loads(ret.read().decode('utf-8'))
 
     return info


### PR DESCRIPTION
When reading Kubernetes configuration, an error like `TypeError: the JSON object must be str, not 'bytes'` might occur. This change forces the parsed JSON into a UTF-8 string, alleviating the problem, and allowing `chaos` to run to completion.