### PR TITLE
Use 'ActivityFailed' exception instead of 'FailedActivity' in chaosk8s/pods

### DIFF
--- a/chaosk8s/actions.py
+++ b/chaosk8s/actions.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
 import json
 import os.path
-from typing import Union
 
-from chaoslib.exceptions import FailedActivity
-from chaoslib.types import MicroservicesStatus, Secrets
-from logzero import logger
+import yaml
+from chaoslib.exceptions import ActivityFailed
+from chaoslib.types import Secrets
 from kubernetes import client
 from kubernetes.client.rest import ApiException
-import yaml
+from logzero import logger
 
 from chaosk8s import create_k8s_api_client
-
 
 __all__ = ["start_microservice", "kill_microservice", "scale_microservice",
            "remove_service_endpoint"]
@@ -32,7 +30,7 @@ def start_microservice(spec_path: str, ns: str = "default",
         elif ext in ['.yml', '.yaml']:
             deployment = yaml.load(f.read())
         else:
-            raise FailedActivity(
+            raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))
 
     v1 = client.AppsV1beta1Api(api)
@@ -111,6 +109,6 @@ def scale_microservice(name: str, replicas: int, ns: str = "default",
     try:
         v1.patch_namespaced_deployment_scale(name, namespace=ns, body=body)
     except ApiException as e:
-        raise FailedActivity(
+        raise ActivityFailed(
             "failed to scale '{s}' to {r} replicas: {e}".format(
                 s=name, r=replicas, e=str(e)))

--- a/chaosk8s/node/probes.py
+++ b/chaosk8s/node/probes.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+
 from chaoslib.types import Configuration, Secrets
 from kubernetes import client
 

--- a/chaosk8s/pod/actions.py
+++ b/chaosk8s/pod/actions.py
@@ -3,10 +3,11 @@ import math
 import random
 import re
 
+from chaoslib.exceptions import ActivityFailed
 from chaoslib.types import Secrets
 from kubernetes import client
 from logzero import logger
-from chaoslib.exceptions import ActivityFailed
+
 from chaosk8s import create_k8s_api_client
 
 __all__ = ["terminate_pods"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dateparser
 kubernetes
 logzero
-chaostoolkit-lib>=0.15.1
+chaostoolkit-lib>=0.20.0
 pyyaml

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,9 +2,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from kubernetes import client, config
-import pytest
-
 from chaosk8s import create_k8s_api_client
 
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
 
 from chaosk8s import __version__, discover
 

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -2,7 +2,7 @@
 from unittest.mock import MagicMock, patch, ANY, call
 
 import pytest
-from chaoslib.exceptions import FailedActivity, ActivityFailed
+from chaoslib.exceptions import ActivityFailed
 
 from chaosk8s.pod.actions import terminate_pods
 from chaosk8s.pod.probes import pods_in_phase, pods_not_in_phase
@@ -349,7 +349,7 @@ def test_pods_should_have_been_phase(cl, client, has_conf):
     v1.list_namespaced_pod.return_value = result
     client.CoreV1Api.return_value = v1
 
-    with pytest.raises(FailedActivity) as x:
+    with pytest.raises(ActivityFailed) as x:
         assert pods_in_phase(
             label_selector="app=mysvc", phase="Running") is True
     assert "pod 'app=mysvc' is in phase 'Pending' but should be " \


### PR DESCRIPTION
Have refactored `chaosk8s/pods/actions.py` and  `chaosk8s/pods/pods.py` to use `chaoslib.exceptions.ActivityFailed` instead of `chaoslib.exceptions.FailedActivity`

Signed-off-by: Nithya Natarajan <nithyanatarajn@gmail.com>