### PR TITLE
fix: consider Completed pods as healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -  [Codecov][codecov] integration
 -  Renamed `FailedActivity` to `ActivityFailed` as per [chaostoolkit 0.20.0][0.20.0]. See [PR#20][20]
 -  Add Ability to specify a maximum percentage of pods to be killed [PR#19][19]
+-  Consider `Completed` pods as healthy in the `all_microservices_healthy` probe. See [PR#23][23]
 
 [codecov]: https://codecov.io/gh/chaostoolkit/chaostoolkit-kubernetes
 [0.20.0]: https://github.com/chaostoolkit/chaostoolkit-lib/blob/master/CHANGELOG.md#0200---2018-08-09
@@ -89,7 +90,7 @@
 
 ### Changed
 
--   Moved the `chaosk8s.probes.read_microservice_logs` to 
+-   Moved the `chaosk8s.probes.read_microservice_logs` to
     `chaosk8s.pod.probes.read_pod_logs` for clarity
 -   Make name optional for `chaosk8s.pod.probes.read_pod_logs` as it usually
     more preferred to use a label for that probe

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -33,7 +33,7 @@ def all_microservices_healthy(ns: str = "default",
         phase = p.status.phase
         if phase == "Failed":
             failed.append(p)
-        elif phase != "Running" and phase != "Completed":
+        elif phase not in ("Running", "Completed"):
             not_ready.append(p)
 
     logger.debug("Found {d} failed and {n} not ready pods".format(

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -33,7 +33,7 @@ def all_microservices_healthy(ns: str = "default",
         phase = p.status.phase
         if phase == "Failed":
             failed.append(p)
-        elif phase != "Running":
+        elif phase != "Running" and phase != "Completed":
             not_ready.append(p)
 
     logger.debug("Found {d} failed and {n} not ready pods".format(

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -34,6 +34,30 @@ def test_unhealthy_system_should_be_reported(cl, client, has_conf):
     assert "the system is unhealthy" in str(excinfo)
 
 
+
+@patch('chaosk8s.has_local_config_file', autospec=True)
+@patch('chaosk8s.probes.client', autospec=True)
+@patch('chaosk8s.client')
+def test_completed_and_running_pods_should_be_considered_healthy(cl, client, has_conf):
+    has_conf.return_value = False
+
+    podCompleted = MagicMock()
+    podCompleted.status.phase = "Completed"
+
+    podRunning = MagicMock()
+    podRunning.status.phase = "Running"
+
+    result = MagicMock()
+    result.items = [podCompleted, podRunning]
+
+    v1 = MagicMock()
+    v1.list_namespaced_pod.return_value = result
+    client.CoreV1Api.return_value = v1
+
+    health = all_microservices_healthy()
+    assert health == True
+
+
 @patch('chaosk8s.has_local_config_file', autospec=True)
 @patch('chaosk8s.probes.client', autospec=True)
 @patch('chaosk8s.client')


### PR DESCRIPTION
"Completed" is a valid status for pods created by a Kubernetes cronjob. They should be considered as healthy pods in the "all_microservices_healthy" probe.

Note: I wasn't able to run the tests on my machine, I got the following error:
```
$ pip install -r requirements-dev.txt -r requirements.txt
  Could not find a version that satisfies the requirement chaostoolkit-lib>=0.20.0 (from -r requirements.txt (line 4)) (from versions: 0.1.0)
No matching distribution found for chaostoolkit-lib>=0.20.0 (from -r requirements.txt (line 4))
```

It would be nice to add some detailed contributing guidelines (how to clone, run and test the project).