### PR TITLE
feat: support grace_period_seconds in terminate_pods action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -  Renamed `FailedActivity` to `ActivityFailed` as per [chaostoolkit 0.20.0][0.20.0]. See [PR#20][20]
 -  Add Ability to specify a maximum percentage of pods to be killed [PR#19][19]
 -  Consider `Completed` pods as healthy in the `all_microservices_healthy` probe. See [PR#23][23]
+-  Support a new `grace_period_seconds` parameter in the `terminate_pods` action. See [PR#24][24]
 
 [codecov]: https://codecov.io/gh/chaostoolkit/chaostoolkit-kubernetes
 [0.20.0]: https://github.com/chaostoolkit/chaostoolkit-lib/blob/master/CHANGELOG.md#0200---2018-08-09

--- a/chaosk8s/pod/actions.py
+++ b/chaosk8s/pod/actions.py
@@ -84,10 +84,9 @@ def terminate_pods(label_selector: str = None, name_pattern: str = None,
     logger.debug("Picked pods '{p}' to be terminated".format(
         p=",".join([po.metadata.name for po in pods])))
 
+    body = client.V1DeleteOptions()
     if grace_period >= 0:
         body = client.V1DeleteOptions(grace_period_seconds=grace_period)
-    else:
-        body = client.V1DeleteOptions()
 
     for p in pods:
         res = v1.delete_namespaced_pod(p.metadata.name, ns, body)

--- a/chaosk8s/pod/actions.py
+++ b/chaosk8s/pod/actions.py
@@ -16,6 +16,7 @@ __all__ = ["terminate_pods"]
 def terminate_pods(label_selector: str = None, name_pattern: str = None,
                    all: bool = False, rand: bool = False,
                    mode: str = "fixed", qty: int = 1,
+                   grace_period: int = -1,
                    ns: str = "default", secrets: Secrets = None):
     """
     Terminate a pod gracefully. Select the appropriate pods by label and/or
@@ -36,6 +37,10 @@ def terminate_pods(label_selector: str = None, name_pattern: str = None,
 
     If `rand` is set to `True`, n random pods will be terminated
     Otherwise, the first retrieved n pods will be terminated.
+
+    If `grace_period` is greater than or equal to 0, it will
+    be used as the grace period (in seconds) to terminate the pods.
+    Otherwise, the default pod's grace period will be used.
     """
     # Fail when quantity is less than 0
     if qty < 0:
@@ -79,7 +84,10 @@ def terminate_pods(label_selector: str = None, name_pattern: str = None,
     logger.debug("Picked pods '{p}' to be terminated".format(
         p=",".join([po.metadata.name for po in pods])))
 
-    body = client.V1DeleteOptions()
+    if grace_period >= 0:
+        body = client.V1DeleteOptions(grace_period_seconds=grace_period)
+    else:
+        body = client.V1DeleteOptions()
+
     for p in pods:
-        res = v1.delete_namespaced_pod(
-            p.metadata.name, ns, body)
+        res = v1.delete_namespaced_pod(p.metadata.name, ns, body)


### PR DESCRIPTION
Support a new `grace_period_seconds` parameter in the `terminate_pods` action to configure the period before a pod is allowed to be forcefully killed. See also https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods

Resolves #22

Signed-off-by: Guido García <guido.garciabernardo@telefonica.com>