### PR TITLE
fix: use succeeded instead of completed to filter cronjob pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.18.0...HEAD
 
+### Added
+
+-  Fix: use `Succeeded` instead of `Completed` to filter successful pods created by a cronjob in the `all_microservices_healthy` probe.
+
 ## [0.18.0][] - 2018-10-08
 
 [0.18.0]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.17.0...0.18.0

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -33,7 +33,7 @@ def all_microservices_healthy(ns: str = "default",
         phase = p.status.phase
         if phase == "Failed":
             failed.append(p)
-        elif phase not in ("Running", "Completed"):
+        elif phase not in ("Running", "Succeeded"):
             not_ready.append(p)
 
     logger.debug("Found {d} failed and {n} not ready pods".format(

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -38,17 +38,17 @@ def test_unhealthy_system_should_be_reported(cl, client, has_conf):
 @patch('chaosk8s.has_local_config_file', autospec=True)
 @patch('chaosk8s.probes.client', autospec=True)
 @patch('chaosk8s.client')
-def test_completed_and_running_pods_should_be_considered_healthy(cl, client, has_conf):
+def test_succeeded_and_running_pods_should_be_considered_healthy(cl, client, has_conf):
     has_conf.return_value = False
 
-    podCompleted = MagicMock()
-    podCompleted.status.phase = "Completed"
+    podSucceeded = MagicMock()
+    podSucceeded.status.phase = "Succeeded"
 
     podRunning = MagicMock()
     podRunning.status.phase = "Running"
 
     result = MagicMock()
-    result.items = [podCompleted, podRunning]
+    result.items = [podSucceeded, podRunning]
 
     v1 = MagicMock()
     v1.list_namespaced_pod.return_value = result


### PR DESCRIPTION
Addresses this issue https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/23#issuecomment-427886358

Signed-off-by: Guido García <guido.garciabernardo@telefonica.com>