### PR TITLE
Add probe for pods conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.19.1...HEAD
 
+- Add a probe to check pods conditions [PR#31][31]
+
+[31]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/31
+
 ## [0.19.1][] - 2018-10-08
 
 [0.19.1]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.18.1...0.19.1


### PR DESCRIPTION
Signed-off-by: Devatoria <joris.bonnefoy@datadoghq.com>

Just a quick probe to check the pods conditions, which can be useful to ensure a pod is scheduled, ready, etc.