### PR TITLE
Add a watch function to wait for a deployment to be fully available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Try to read proxy from environment variable "HTTP_PROXY" and set it
   appropriately if it exists
+- Add the `deployment_is_fully_available` probe to wait for a deployment to be fully available [#38][38]
+
+[38]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/38
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.20.0...HEAD
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -11,7 +11,7 @@ from chaosk8s.node.probes import get_nodes
 from chaosk8s.probes import all_microservices_healthy, \
     microservice_available_and_healthy, microservice_is_not_available, \
     service_endpoint_is_initialized, deployment_is_not_fully_available, \
-    read_microservices_logs
+    deployment_is_fully_available, read_microservices_logs
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)
@@ -180,6 +180,46 @@ def test_deployment_is_fully_available_when_it_should_not(cl, client,
     with pytest.raises(ActivityFailed) as excinfo:
         deployment_is_not_fully_available("mysvc")
     assert "microservice 'mysvc' failed to stop running within" in str(excinfo)
+
+
+@patch('chaosk8s.has_local_config_file', autospec=True)
+@patch('chaosk8s.probes.watch', autospec=True)
+@patch('chaosk8s.probes.client', autospec=True)
+@patch('chaosk8s.client')
+def test_deployment_is_fully_available(cl, client, watch, has_conf):
+    has_conf.return_value = False
+    deployment = MagicMock()
+    deployment.spec.replicas = 2
+    deployment.status.ready_replicas = 2
+
+    watcher = MagicMock()
+    watcher.stream = MagicMock()
+    watcher.stream.side_effect = [[{"object": deployment, "type": "ADDED"}]]
+    watch.Watch.return_value = watcher
+
+    assert deployment_is_fully_available("mysvc") is True
+
+
+@patch('chaosk8s.has_local_config_file', autospec=True)
+@patch('chaosk8s.probes.watch', autospec=True)
+@patch('chaosk8s.probes.client', autospec=True)
+@patch('chaosk8s.client')
+def test_deployment_is_not_fully_available_when_it_should(cl, client,
+                                                          watch, has_conf):
+    has_conf.return_value = False
+    deployment = MagicMock()
+    deployment.spec.replicas = 2
+    deployment.status.ready_replicas = 1
+
+    watcher = MagicMock()
+    watcher.stream = MagicMock()
+    watcher.stream.side_effect = urllib3.exceptions.ReadTimeoutError(
+        None, None, None)
+    watch.Watch.return_value = watcher
+
+    with pytest.raises(ActivityFailed) as excinfo:
+        deployment_is_fully_available("mysvc")
+    assert "microservice 'mysvc' failed to recover within" in str(excinfo)
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)


### PR DESCRIPTION
Here's a small PR to add the same feature as `deployment_is_not_fully_available` function but to wait for a deployment to be fully available instead.

It aims to be used as a probe in the steady state hypothesis to wait for the deployment to be healthy after some actions, like after killing a pod. It avoids to use the `pauses` field which can be really annoying when running multiple experiments since it takes a fixed time.