### PR TITLE
Fixing bug when deleting nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
 - Add the `deployment_is_fully_available` probe to wait for a deployment to be fully available [#38][38]
 - Fix calls to `delete_namespaced_*` so that the `body` argument is passed
   a named argument [#42][42]. A follow up to [#34][34]
+- Fix calls to `delete_nodes` so that the `body` argument is passed
+  a named argument [#44][44].
 
 [38]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/38
 [42]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/issues/42
+[44]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/44
 
 ## [0.20.0][] - 2018-03-25
 

--- a/chaosk8s/node/actions.py
+++ b/chaosk8s/node/actions.py
@@ -74,7 +74,9 @@ def delete_nodes(label_selector: str = None, all: bool = False,
     body = client.V1DeleteOptions()
     for n in nodes:
         res = v1.delete_node(
-            n.metadata.name, body, grace_period_seconds=grace_period_seconds)
+            n.metadata.name,
+            body=body,
+            grace_period_seconds=grace_period_seconds)
 
         if res.status != "Success":
             logger.debug("Terminating nodes failed: {}".format(res.message))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -89,7 +89,8 @@ def test_delete_nodes(cl, client, has_conf):
 
     delete_nodes(label_selector="k=mynode")
 
-    v1.delete_node.assert_called_with("mynode", ANY, grace_period_seconds=None)
+    v1.delete_node.assert_called_with(
+        "mynode", body=ANY, grace_period_seconds=None)
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)
@@ -114,7 +115,8 @@ def test_delete_nodes(cl, client, has_conf):
 
     delete_nodes(label_selector="k=mynode")
 
-    v1.delete_node.assert_called_with("mynode", ANY, grace_period_seconds=None)
+    v1.delete_node.assert_called_with(
+        "mynode", body=ANY, grace_period_seconds=None)
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)


### PR DESCRIPTION
When running the delete_action previously, it failed with a
[2019-06-21 09:17:14 INFO] Action: delete_nodes
[2019-06-21 09:17:14 ERROR]   => failed: TypeError: delete_node() takes 2 positional arguments but 3 were given

I'll add the full `chaostoolkit.log` in the next comment with both the failing code and the succeeding code

Signed-off-by: AlbertoSH <alberto.sanz.herrero@gmail.com>