### PR TITLE
fixes for microservice_available_and_healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.21.0...HEAD
 
+### Changed
+
+- Fix `microservice_available_and_healthy` to use `metadata.name` field as a name selector
+  as newever version of K8s no longer add a name label by defult [#53][53].
+- Fix `microservice_available_and_healthy` to only use `label_selector` if one is passed in [#53][53].
+
 ## [0.21.0][] - 2019-09-02
 
 [0.21.0]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.20.0...0.21.0

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -53,7 +53,9 @@ def microservice_available_and_healthy(
         secrets: Secrets = None) -> Union[bool, None]:
     """
     Lookup a deployment by `name` in the namespace `ns`.
+
     The selected resources are matched by the given `label_selector`.
+
     Raises :exc:`chaoslib.exceptions.ActivityFailed` when the state is not
     as expected.
     """

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -49,24 +49,24 @@ def all_microservices_healthy(ns: str = "default",
 
 def microservice_available_and_healthy(
         name: str, ns: str = "default",
-        label_selector: str = "name in ({name})",
+        label_selector: str = None,
         secrets: Secrets = None) -> Union[bool, None]:
     """
     Lookup a deployment by `name` in the namespace `ns`.
-
     The selected resources are matched by the given `label_selector`.
-
     Raises :exc:`chaoslib.exceptions.ActivityFailed` when the state is not
     as expected.
     """
-    label_selector = label_selector.format(name=name)
+
+    field_selector = "metadata.name={name}".format(name=name)
     api = create_k8s_api_client(secrets)
 
     v1 = client.AppsV1beta1Api(api)
     if label_selector:
-        ret = v1.list_namespaced_deployment(ns, label_selector=label_selector)
+        ret = v1.list_namespaced_deployment(ns, field_selector=field_selector,
+                                            label_selector=label_selector)
     else:
-        ret = v1.list_namespaced_deployment(ns)
+        ret = v1.list_namespaced_deployment(ns, field_selector=field_selector)
 
     logger.debug("Found {d} deployment(s) named '{n}' in ns '{s}'".format(
         d=len(ret.items), n=name, s=ns))


### PR DESCRIPTION
Fixes a couple of issues with microservice_available_and_healthy
- Currently label_selector gets used even if one is not provided.
- Deployments do not have a "name" label by default, use the field selector to query for the "name" instead.

Signed-off-by: Rodrigo Menezes <rodrigomenezes@pinterest.com>