### PR TITLE
Updating kubernetes api version to support the latest `apps/v1` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Fix `microservice_available_and_healthy` to use `metadata.name` field as a name selector
   as newever version of K8s no longer add a name label by defult [#53][53].
 - Fix `microservice_available_and_healthy` to only use `label_selector` if one is passed in [#53][53].
+- Updates to `kubectl` api version to point to `apps/v1` instead of `apps/v1beta1`  [#65][65]
+
+[65]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/65
 
 ## [0.21.0][] - 2019-09-02
 

--- a/chaosk8s/actions.py
+++ b/chaosk8s/actions.py
@@ -33,7 +33,7 @@ def start_microservice(spec_path: str, ns: str = "default",
             raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     resp = v1.create_namespaced_deployment(ns, body=deployment)
     return resp
 
@@ -52,7 +52,7 @@ def kill_microservice(name: str, ns: str = "default",
     label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     if label_selector:
         ret = v1.list_namespaced_deployment(ns, label_selector=label_selector)
     else:
@@ -66,7 +66,7 @@ def kill_microservice(name: str, ns: str = "default",
         res = v1.delete_namespaced_deployment(
             d.metadata.name, ns, body=body)
 
-    v1 = client.ExtensionsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     if label_selector:
         ret = v1.list_namespaced_replica_set(ns, label_selector=label_selector)
     else:
@@ -113,7 +113,7 @@ def scale_microservice(name: str, replicas: int, ns: str = "default",
     """
     api = create_k8s_api_client(secrets)
 
-    v1 = client.ExtensionsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     body = {"spec": {"replicas": replicas}}
     try:
         v1.patch_namespaced_deployment_scale(name, namespace=ns, body=body)

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -63,7 +63,7 @@ def microservice_available_and_healthy(
     field_selector = "metadata.name={name}".format(name=name)
     api = create_k8s_api_client(secrets)
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     if label_selector:
         ret = v1.list_namespaced_deployment(ns, field_selector=field_selector,
                                             label_selector=label_selector)
@@ -160,7 +160,7 @@ def _deployment_readiness_has_state(name: str, ready: bool,
     """
     label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     w = watch.Watch()
     timeout = int(timeout)
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -359,7 +359,7 @@ def test_killing_microservice_deletes_deployment(cl, client, has_conf):
     has_conf.return_value = False
 
     v1 = MagicMock()
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     body = MagicMock()
     client.V1DeleteOptions.return_value = body
@@ -382,7 +382,7 @@ def test_killing_microservice_deletes_rs(cl, client, has_conf):
     has_conf.return_value = False
 
     v1 = MagicMock()
-    client.ExtensionsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     body = MagicMock()
     client.V1DeleteOptions.return_value = body

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -70,7 +70,7 @@ def test_expecting_healthy_microservice_should_be_reported_when_not(cl,
 
     v1 = MagicMock()
     v1.list_namespaced_deployment.return_value = result
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     with pytest.raises(ActivityFailed) as excinfo:
         microservice_available_and_healthy("mysvc")


### PR DESCRIPTION
This PR is fix related to the issue #63 & #62 . A part of these issues have been already addressed in Pull request : https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/53 

Changes include:

- Updated `chaosk8s\actions.py` & `chaosk8s\probes.py`
- Updated related tests too.