### PR TITLE
add remove_statefulset activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@
 - Fix `microservice_available_and_healthy` to only use `label_selector` if one is passed in [#53][53].
 - Updates to `kubectl` api version to point to `apps/v1` instead of `apps/v1beta1`  [#65][65]
 - Added function to execute remote commands in a container
+- Remove check Kubernetes statefulset by name and label  [#70][70]
 - Added action to scale statefulsets [#73][73]
 
+[53]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/53
 [65]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/65
+[70]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/70
 [73]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/73
 
 ## [0.21.0][] - 2019-09-02

--- a/chaosk8s/statefulset/actions.py
+++ b/chaosk8s/statefulset/actions.py
@@ -3,10 +3,11 @@ from chaoslib.exceptions import ActivityFailed
 from chaoslib.types import Secrets
 from kubernetes import client
 from kubernetes.client.rest import ApiException
+from logzero import logger
 
 from chaosk8s import create_k8s_api_client
 
-__all__ = ["scale_statefulset"]
+__all__ = ["scale_statefulset", "remove_statefulset"]
 
 
 def scale_statefulset(name: str, replicas: int, ns: str = "default",
@@ -25,3 +26,34 @@ def scale_statefulset(name: str, replicas: int, ns: str = "default",
         raise ActivityFailed(
             "failed to scale '{s}' to {r} replicas: {e}".format(
                 s=name, r=replicas, e=str(e)))
+
+
+def remove_statefulset(name: str = None, ns: str = "default",
+                       label_selector: str = None, secrets: Secrets = None):
+    """
+    Remove a statefulset by `name` in the namespace `ns`.
+
+    The statefulset is removed by deleting it without
+        a graceful period to trigger an abrupt termination.
+
+    The selected resources are matched by the given `label_selector`.
+    """
+    field_selector = "metadata.name={name}".format(name=name)
+    api = create_k8s_api_client(secrets)
+
+    v1 = client.AppsV1Api(api)
+    if label_selector:
+        ret = v1.list_namespaced_stateful_set(
+            ns, field_selector=field_selector,
+            label_selector=label_selector)
+    else:
+        ret = v1.list_namespaced_stateful_set(ns,
+                                              field_selector=field_selector)
+
+    logger.debug("Found {d} statefulset(s) named '{n}' in ns '{s}'".format(
+        d=len(ret.items), n=name, s=ns))
+
+    body = client.V1DeleteOptions()
+    for d in ret.items:
+        res = v1.delete_namespaced_stateful_set(
+            d.metadata.name, ns, body=body)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -9,7 +9,6 @@ from chaosk8s.actions import start_microservice, kill_microservice
 from chaosk8s.node.actions import cordon_node, create_node, delete_nodes, \
     uncordon_node, drain_nodes
 
-
 @patch('chaosk8s.has_local_config_file', autospec=True)
 def test_cannot_process_other_than_yaml_and_json(has_conf):
     has_conf.return_value = False

--- a/tests/test_statefulset.py
+++ b/tests/test_statefulset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 
-from chaosk8s.statefulset.actions import scale_statefulset
+from chaosk8s.statefulset.actions import scale_statefulset, remove_statefulset
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)
@@ -20,4 +20,47 @@ def test_scale_statefulset(cl, client, has_conf):
     assert v1.patch_namespaced_stateful_set.call_count == 1
     v1.patch_namespaced_stateful_set.assert_called_with(
         "my-statefulset", namespace="default", body=body)
+
+@patch('chaosk8s.has_local_config_file', autospec=True)
+@patch('chaosk8s.statefulset.actions.client', autospec=True)
+@patch('chaosk8s.client')
+def test_removing_statefulset_with_name(cl, client, has_conf):
+    has_conf.return_value = False
+
+    v1 = MagicMock()
+    client.AppsV1Api.return_value = v1
+
+    result = MagicMock()
+    result.items = [MagicMock()]
+    result.items[0].metadata.name = "mystatefulset"
+    v1.list_namespaced_stateful_set.return_value = result
+
+    remove_statefulset("mystatefulset")
+
+    assert v1.delete_namespaced_stateful_set.call_count == 1
+    v1.delete_namespaced_stateful_set.assert_called_with(
+        "mystatefulset", "default", body=ANY)
+
+
+@patch('chaosk8s.has_local_config_file', autospec=True)
+@patch('chaosk8s.statefulset.actions.client', autospec=True)
+@patch('chaosk8s.client')
+def test_removing_statefulset_with_label_selector(cl, client, has_conf):
+    has_conf.return_value = False
+
+    v1 = MagicMock()
+    client.AppsV1Api.return_value = v1
+
+    result = MagicMock()
+    result.items = [MagicMock()]
+    result.items[0].metadata.name = "mystatefulset"
+    result.items[0].metadata.labels.app = "my-super-app"
+    v1.list_namespaced_stateful_set.return_value = result
+
+    label_selector = "app=my-super-app"
+    remove_statefulset("mystatefulset", label_selector=label_selector)
+
+    assert v1.delete_namespaced_stateful_set.call_count == 1
+    v1.delete_namespaced_stateful_set.assert_called_with(
+        "mystatefulset", "default", body=ANY)
 


### PR DESCRIPTION
add a new action for killing statefulset pod 

Kill a statefulset by `name` in the namespace `ns`.
The statefulset is killed by deleting it without a graceful period to trigger an abrupt termination.
The selected resources are matched by the given `label_selector`.