### PR TITLE
Fix yaml load warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Added action to scale statefulsets [#73][73]
 - Added action to create a statefulset from a json/yaml file [#74][74]
 - Added action to create a service endpoint from a json/yaml file [#68][68]
+- Fix yaml load warning #75
+
 
 [53]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/53
 [65]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/65
@@ -22,6 +24,7 @@
 [70]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/70
 [73]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/73
 [74]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/74
+[75]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/75
 
 ## [0.21.0][] - 2019-09-02
 

--- a/chaosk8s/actions.py
+++ b/chaosk8s/actions.py
@@ -28,7 +28,7 @@ def start_microservice(spec_path: str, ns: str = "default",
         if ext == '.json':
             deployment = json.loads(f.read())
         elif ext in ['.yml', '.yaml']:
-            deployment = yaml.load(f.read())
+            deployment = yaml.safe_load(f.read())
         else:
             raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))

--- a/chaosk8s/service/actions.py
+++ b/chaosk8s/service/actions.py
@@ -25,7 +25,7 @@ def create_service_endpoint(spec_path: str, ns: str = "default",
         if ext == '.json':
             service = json.loads(f.read())
         elif ext in ['.yml', '.yaml']:
-            service = yaml.load(f.read())
+            service = yaml.safe_load(f.read())
         else:
             raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))

--- a/chaosk8s/statefulset/actions.py
+++ b/chaosk8s/statefulset/actions.py
@@ -27,7 +27,7 @@ def create_statefulset(spec_path: str, ns: str = "default",
         if ext == '.json':
             statefulset = json.loads(f.read())
         elif ext in ['.yml', '.yaml']:
-            statefulset = yaml.load(f.read())
+            statefulset = yaml.safe_load(f.read())
         else:
             raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))


### PR DESCRIPTION
When we call yaml.load a warning message is displayed :
chaostoolkit-kubernetes\chaosk8s\service\actions.py:28: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  service = yaml.load(f.read())

This PR is here to fix it