### PR TITLE
Update `deployment_is_not_fully_available` and `deployment_is_fully_available` for newer k8s versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.22.0...HEAD
 
+### Changed
+
+- Fix `deployment_is_not_fully_available` and `deployment_is_fully_available` to use
+  `metadata.name` field as a name selector as newer version of K8s no longer add a
+  name label by default [#85][85].
+- Fix `deployment_is_not_fully_available` and `deployment_is_fully_available` to only
+  use `label_selector` if one is passed in [#85][85].
+
+[85]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/pull/85
+
 ## [0.22.0][] - 2020-01-10
 
 [0.22.0]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.21.0...0.22.0

--- a/chaosk8s/probes.py
+++ b/chaosk8s/probes.py
@@ -64,7 +64,7 @@ def service_endpoint_is_initialized(name: str, ns: str = "default",
 
 # moved to deployment/probes.py
 def deployment_is_not_fully_available(name: str, ns: str = "default",
-                                      label_selector: str = "name in ({name})",
+                                      label_selector: str = None,
                                       timeout: int = 30,
                                       secrets: Secrets = None):
     """
@@ -78,7 +78,7 @@ def deployment_is_not_fully_available(name: str, ns: str = "default",
 
 # moved to deployment/probes.py
 def deployment_is_fully_available(name: str, ns: str = "default",
-                                  label_selector: str = "name in ({name})",
+                                  label_selector: str = None,
                                   timeout: int = 30,
                                   secrets: Secrets = None):
     """


### PR DESCRIPTION
- Fix `deployment_is_not_fully_available` and `deployment_is_fully_available` to use `metadata.name` field as a name selector as newer version of K8s no longer add a name label by default
- Fix `deployment_is_not_fully_available` and `deployment_is_fully_available` to only use `label_selector` if one is passed in