### PR TITLE
use container name in dictionary instead of pod's to return logs

### DIFF
--- a/chaosk8s/pod/probes.py
+++ b/chaosk8s/pod/probes.py
@@ -76,7 +76,7 @@ def read_pod_logs(name: str = None, last: Union[str, None] = None,
         name = p.metadata.name
         logger.debug("Fetching logs for pod '{n}'".format(n=name))
         r = v1.read_namespaced_pod_log(name, **params)
-        logs[name] = r.read().decode('utf-8')
+        logs[container_name or "stdout"] = r.read().decode('utf-8')
 
     return logs
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -242,7 +242,7 @@ def test_fetch_last_logs(cl, client, has_conf):
     logs = read_microservices_logs("myapp")
 
     assert pod.metadata.name in logs
-    assert logs[pod.metadata.name] == "hello"
+    assert logs["stdout"] == "hello"
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)


### PR DESCRIPTION
Related to the issue:
https://github.com/chaostoolkit/chaostoolkit-kubernetes/issues/95

- use container name in the dictionary to use as target for tolerance
- if container name was not provided  - use "stdout"