### PR TITLE
Use AppsV1Api instead of the deprecated beta api

### DIFF
--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -31,7 +31,7 @@ def create_deployment(spec_path: str, ns: str = "default",
             raise ActivityFailed(
                 "cannot process {path}".format(path=spec_path))
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     resp = v1.create_namespaced_deployment(ns, body=deployment)
 
 
@@ -49,7 +49,7 @@ def delete_deployment(name: str, ns: str = "default",
     label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     if label_selector:
         ret = v1.list_namespaced_deployment(ns, label_selector=label_selector)
     else:

--- a/chaosk8s/deployment/probes.py
+++ b/chaosk8s/deployment/probes.py
@@ -32,7 +32,7 @@ def deployment_available_and_healthy(
     field_selector = "metadata.name={name}".format(name=name)
     api = create_k8s_api_client(secrets)
 
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     if label_selector:
         ret = v1.list_namespaced_deployment(ns, field_selector=field_selector,
                                             label_selector=label_selector)
@@ -71,7 +71,7 @@ def _deployment_readiness_has_state(
     """
     field_selector = "metadata.name={name}".format(name=name)
     api = create_k8s_api_client(secrets)
-    v1 = client.AppsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     w = watch.Watch()
     timeout = int(timeout)
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -27,7 +27,7 @@ def test_cannot_process_other_than_yaml_and_json(has_conf):
 @patch('chaosk8s.deployment.actions.client', autospec=True)
 def test_create_deployment(client, api, json, open):
     v1 = MagicMock()
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
     json.loads.return_value = {"Kind": "Deployment"}
 
     create_deployment(spec_path="depl.json")
@@ -41,7 +41,7 @@ def test_delete_deployment(client, api):
     depl1 = V1Deployment(metadata=V1ObjectMeta(name="depl1"))
     depl2 = V1Deployment(metadata=V1ObjectMeta(name="depl2"))
     v1 = MagicMock()
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
     v1.list_namespaced_deployment.return_value = V1DeploymentList(items=(depl1, depl2))
 
     delete_deployment("fake_name", "fake_ns")
@@ -102,7 +102,7 @@ def test_expecting_a_healthy_microservice_should_be_reported_when_not(cl,
 
     v1 = MagicMock()
     v1.list_namespaced_deployment.return_value = result
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     with pytest.raises(ActivityFailed) as x:
         deployment_available_and_healthy("mysvc")
@@ -130,7 +130,7 @@ def test_expecting_a_healthy_microservice(cl,
 
     v1 = MagicMock()
     v1.list_namespaced_deployment.return_value = result
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     deployment = MagicMock()
     deployment.spec.replicas = 2

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -361,7 +361,7 @@ def test_killing_microservice_deletes_deployment(cl, client, has_conf):
     has_conf.return_value = False
 
     v1 = MagicMock()
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     body = MagicMock()
     client.V1DeleteOptions.return_value = body

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -72,7 +72,7 @@ def test_expecting_healthy_microservice_should_be_reported_when_not(cl,
 
     v1 = MagicMock()
     v1.list_namespaced_deployment.return_value = result
-    client.AppsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     with pytest.raises(ActivityFailed) as excinfo:
         microservice_available_and_healthy("mysvc")


### PR DESCRIPTION
This is related to #63

Running the sample kubernetes experiments on a Kubernetes cluster 1.16 results in 404. With this changes applied, the experiment is able to correctly query the state of my deployments.

Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>