### PR TITLE
Use V1 API for `actions.scale_deployment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.24.1...HEAD
 
+### Changed
+
+- Fix `actions.scale_deployment` to use AppsV1Api in line with the rest of the actions.
+
 ## [0.24.1][] - 2020-10-29
 
 [0.24.1]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.24.0...0.24.1

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -10,7 +10,7 @@ from kubernetes.client.rest import ApiException
 
 from chaosk8s import create_k8s_api_client
 
-__all__ = ["create_deployment", "delete_deployment"]
+__all__ = ["create_deployment", "delete_deployment", "scale_deployment"]
 
 
 def create_deployment(spec_path: str, ns: str = "default",
@@ -70,10 +70,10 @@ def scale_deployment(name: str, replicas: int, ns: str = "default",
     """
     api = create_k8s_api_client(secrets)
 
-    v1 = client.ExtensionsV1beta1Api(api)
+    v1 = client.AppsV1Api(api)
     body = {"spec": {"replicas": replicas}}
     try:
-        v1.patch_namespaced_deployment_scale(name, namespace=ns, body=body)
+        v1.patch_namespaced_deployment(name=name, namespace=ns, body=body)
     except ApiException as e:
         raise ActivityFailed(
             "failed to scale '{s}' to {r} replicas: {e}".format(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -60,12 +60,12 @@ def test_delete_deployment(client, api):
 @patch('chaosk8s.deployment.actions.client', autospec=True)
 def test_scale_deployment(client, api):
     v1 = MagicMock()
-    client.ExtensionsV1beta1Api.return_value = v1
+    client.AppsV1Api.return_value = v1
 
     scale_deployment("fake", 3, "fake_ns")
 
     body = {"spec": {"replicas": 3}}
-    v1.patch_namespaced_deployment_scale.assert_called_with("fake", namespace="fake_ns", body=body)
+    v1.patch_namespaced_deployment.assert_called_with(name="fake", namespace="fake_ns", body=body)
 
 
 @patch('chaosk8s.has_local_config_file', autospec=True)


### PR DESCRIPTION
Hey all,

This PR fixes the `actions.scale_deployment` action by bringing it inline with the rest of the class and using the `AppsV1` API.

I've also included it in `__all__`, now that it seems to work properly (for me at least!).

Thanks so much for the software!