### PR TITLE
Fix name parameters to be used in field selector.

### DIFF
--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -35,22 +35,25 @@ def create_deployment(spec_path: str, ns: str = "default",
     resp = v1.create_namespaced_deployment(ns, body=deployment)
 
 
-def delete_deployment(name: str, ns: str = "default",
-                      label_selector: str = "name in ({name})",
-                      secrets: Secrets = None):
+def delete_deployment(name: str = None, ns: str = "default",
+                      label_selector: str = None, secrets: Secrets = None):
     """
-    Delete a deployment by `name` in the namespace `ns`.
+    Delete a deployment by `name` or `label_selector` in the namespace `ns`.
 
     The deployment is deleted without a graceful period to trigger an abrupt
     termination.
 
-    The selected resources are matched by the given `label_selector`.
+    If neither `name` nor `label_selector` is specified, all the deployments
+    will be deleted in the namespace.
     """
-    label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
 
     v1 = client.AppsV1Api(api)
-    if label_selector:
+
+    if name:
+        ret = v1.list_namespaced_deployment(
+            ns, field_selector="metadata.name={}".format(name))
+    elif label_selector:
         ret = v1.list_namespaced_deployment(ns, label_selector=label_selector)
     else:
         ret = v1.list_namespaced_deployment(ns)

--- a/chaosk8s/pod/actions.py
+++ b/chaosk8s/pod/actions.py
@@ -225,21 +225,23 @@ def _select_pods(v1: client.CoreV1Api = None, label_selector: str = None,
     return pods
 
 
-def delete_pods(name: str, ns: str = "default",
-                label_selector: str = "name in ({name})",
-                secrets: Secrets = None):
+def delete_pods(name: str = None, ns: str = "default",
+                label_selector: str = None, secrets: Secrets = None):
     """
-    Delete pods by `name` in the namespace `ns`.
+    Delete pods by `name` or `label_selector` in the namespace `ns`.
 
     The pods are deleted without a graceful period to trigger an abrupt
     termination.
 
-    The selected resources are matched by the given `label_selector`.
+    If neither of `name` and `label_selector` is specified, all the pods will
+    be deleted in the namespace.
     """
-    label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
     v1 = client.CoreV1Api(api)
-    if label_selector:
+    if name:
+        ret = v1.list_namespaced_pod(
+            ns, field_selector="metadata.name={}".format(name))
+    elif label_selector:
         ret = v1.list_namespaced_pod(ns, label_selector=label_selector)
     else:
         ret = v1.list_namespaced_pod(ns)

--- a/chaosk8s/replicaset/actions.py
+++ b/chaosk8s/replicaset/actions.py
@@ -7,21 +7,23 @@ from chaosk8s import create_k8s_api_client
 __all__ = ["delete_replica_set"]
 
 
-def delete_replica_set(name: str, ns: str = "default",
-                       label_selector: str = "name in ({name})",
-                       secrets: Secrets = None):
+def delete_replica_set(name: str = None, ns: str = "default",
+                       label_selector: str = None, secrets: Secrets = None):
     """
-    Delete a replica set by `name` in the namespace `ns`.
+    Delete a replica set by `name` or `label_selector` in the namespace `ns`.
 
     The replica set is deleted without a graceful period to trigger an abrupt
     termination.
 
-    The selected resources are matched by the given `label_selector`.
+    If neither `name` nor `label_selector` is specified, all the replica sets
+    will be deleted in the namespace.
     """
-    label_selector = label_selector.format(name=name)
     api = create_k8s_api_client(secrets)
     v1 = client.ExtensionsV1beta1Api(api)
-    if label_selector:
+    if name:
+        ret = v1.list_namespaced_replica_set(
+            ns, field_selector="metadata.name={}".format(name))
+    elif label_selector:
         ret = v1.list_namespaced_replica_set(ns, label_selector=label_selector)
     else:
         ret = v1.list_namespaced_replica_set(ns)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -46,7 +46,8 @@ def test_delete_deployment(client, api):
 
     delete_deployment("fake_name", "fake_ns")
 
-    v1.list_namespaced_deployment.assert_called_with("fake_ns", label_selector=ANY)
+    v1.list_namespaced_deployment.assert_called_with(
+        "fake_ns", field_selector="metadata.name=fake_name")
     v1.delete_namespaced_deployment.assert_has_calls(
         calls=[
             call(depl1.metadata.name, "fake_ns", body=ANY),

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -8,7 +8,7 @@ from chaosk8s.replicaset.actions import delete_replica_set
 
 @patch('chaosk8s.replicaset.actions.create_k8s_api_client', autospec=True)
 @patch('chaosk8s.replicaset.actions.client', autospec=True)
-def test_create_deployment(client, api):
+def test_delete_replica_set(client, api):
     v1 = MagicMock()
     client.ExtensionsV1beta1Api.return_value = v1
 
@@ -19,7 +19,8 @@ def test_create_deployment(client, api):
 
     delete_replica_set("fake", "fake_ns")
 
-    v1.list_namespaced_replica_set.assert_called_with("fake_ns", label_selector="name in (fake)")
+    v1.list_namespaced_replica_set.assert_called_with(
+        "fake_ns", field_selector="metadata.name=fake")
     v1.delete_namespaced_replica_set.assert_has_calls(
         [
             call("repl1", "fake_ns", body=ANY),

--- a/tests/test_statefulset.py
+++ b/tests/test_statefulset.py
@@ -42,6 +42,8 @@ def test_removing_statefulset_with_name(cl, client, has_conf):
 
     remove_statefulset("mystatefulset")
 
+    v1.list_namespaced_stateful_set.assert_called_with(
+        "default", field_selector="metadata.name=mystatefulset")
     assert v1.delete_namespaced_stateful_set.call_count == 1
     v1.delete_namespaced_stateful_set.assert_called_with(
         "mystatefulset", "default", body=ANY)
@@ -63,8 +65,10 @@ def test_removing_statefulset_with_label_selector(cl, client, has_conf):
     v1.list_namespaced_stateful_set.return_value = result
 
     label_selector = "app=my-super-app"
-    remove_statefulset("mystatefulset", label_selector=label_selector)
+    remove_statefulset(label_selector=label_selector)
 
+    v1.list_namespaced_stateful_set.assert_called_with(
+        "default", label_selector=label_selector)
     assert v1.delete_namespaced_stateful_set.call_count == 1
     v1.delete_namespaced_stateful_set.assert_called_with(
         "mystatefulset", "default", body=ANY)


### PR DESCRIPTION
Signed-off-by: ykskb <yoheikusakabe@gmail.com>

As the issue https://github.com/chaostoolkit/chaostoolkit-kubernetes/issues/108 mentions, using label selector formatted with name as `name in ({name})` does not match any resources by name.

This PR fixes `delete_pods`, `delete_deployment`, `delete_replicaset` and `remove_statefulset` to use the field selector for name parameter to be matched in `metadata.name` property. If `label_selector` param is provided, then those functions would use the provided label query as it is into label selector.