### PR TITLE
Fix cmd splitting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
--Fixed the cmd splitting issue, therefore the shell commands will now parse correctly
+-Fixed the cmd splitting issue, therefore the shell commands will now parse correctly [#133][133]
 
 
 ## [0.26.2][] - 2022-03-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -Fixed the cmd splitting issue, therefore the shell commands will now parse correctly [#133][133]
 
+[133]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/issues/133
 
 ## [0.26.2][] - 2022-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.26.2...HEAD
 
-## [0.26.3][] - 2022-04-05
-
 ### Fixed
 
 -Fixed the cmd splitting issue, therefore the shell commands will now parse correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.26.2...HEAD
 
+## [0.26.3][] - 2022-04-05
+
+### Fixed
+
+-Fixed the cmd splitting issue, therefore the shell commands will now parse correctly
+
+
 ## [0.26.2][] - 2022-03-30
 
 [0.26.2]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.26.1...0.26.2

--- a/chaosk8s/pod/actions.py
+++ b/chaosk8s/pod/actions.py
@@ -3,6 +3,7 @@ import json
 import math
 import random
 import re
+import shlex
 from typing import Any, Dict, List, Union
 
 from chaoslib.exceptions import ActivityFailed
@@ -128,7 +129,7 @@ def exec_in_pods(
         v1, label_selector, name_pattern, all, rand, mode, qty, ns, order
     )
 
-    exec_command = cmd.strip().split() if isinstance(cmd, str) else cmd
+    exec_command = shlex.split(cmd) if isinstance(cmd, str) else cmd
 
     results = []
     for po in pods:

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -1128,3 +1128,39 @@ def test_exec_in_pods_stderr_sometimes_not_json(cl, client, has_conf):
     assert stream.stream.call_args[1]["command"] == ["dummy", "-a", "-b", "-c"]
     assert result[0]["exit_code"] == 1
     assert result[0]["stderr"] == "BOOM"
+
+
+@patch("chaosk8s.has_local_config_file", autospec=True)
+@patch("chaosk8s.pod.actions.client", autospec=True)
+@patch("chaosk8s.client")
+def test_exec_in_pods_cmd_as_shlex(cl, client, has_conf):
+    has_conf.return_value = False
+
+    container1 = MagicMock()
+    container1.name = "container1"
+
+    pod1 = MagicMock()
+    pod1.metadata.name = "my-app-1"
+    pod1.spec.containers = [container1]
+
+    result = MagicMock()
+    result.items = [pod1]
+
+    v1 = MagicMock()
+    v1.list_namespaced_pod.return_value = result
+    client.CoreV1Api.return_value = v1
+
+    stream.stream = MagicMock()
+    stream.stream.return_value.read_channel = MagicMock()
+    stream.stream.return_value.read_channel.return_value = '{"status":"Success"}'
+
+    command = ["/bin/sh -c ls"]
+
+    result = exec_in_pods(
+        name_pattern="my-app-1",
+        cmd=command,
+        container_name="container1",
+    )
+    assert stream.stream.call_count == 1
+    assert stream.stream.call_args[1]["command"] == command
+    assert result[0]["exit_code"] == 0

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -1162,5 +1162,5 @@ def test_exec_in_pods_cmd_as_shlex(cl, client, has_conf):
         container_name="container1",
     )
     assert stream.stream.call_count == 1
-    assert stream.stream.call_args[1]["command"] == ["/bin/sh -c ls"]
+    assert stream.stream.call_args[1]["command"] == ["/bin/sh", "-c", "ls"]
     assert result[0]["exit_code"] == 0

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -1154,7 +1154,7 @@ def test_exec_in_pods_cmd_as_shlex(cl, client, has_conf):
     stream.stream.return_value.read_channel = MagicMock()
     stream.stream.return_value.read_channel.return_value = '{"status":"Success"}'
 
-    command = ["/bin/sh -c ls"]
+    command = "/bin/sh -c ls"
 
     result = exec_in_pods(
         name_pattern="my-app-1",
@@ -1162,5 +1162,5 @@ def test_exec_in_pods_cmd_as_shlex(cl, client, has_conf):
         container_name="container1",
     )
     assert stream.stream.call_count == 1
-    assert stream.stream.call_args[1]["command"] == command
+    assert stream.stream.call_args[1]["command"] == ["/bin/sh -c ls"]
     assert result[0]["exit_code"] == 0


### PR DESCRIPTION
fixed the cmd splitting issue, therefore the shell commands will now parse correctly. 