### PR TITLE
Updated Pod Eviction Method for Drain Node Scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
 
-### Removed
-
-Removed method client.V1beta1Eviction()
-
 ### Updated
 
--Updated Pod Eviction Method for Drain Node Scenarios
+-Updated the API/v1 as per the lifecycle of Kubernetes API which states the pod eviction has been V1beta1Eviction was deprecated and removed in Kubernetes 1.22.
 
 ## [Unreleased][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Updated
+
+-Updated Pod Eviction Method for Drain Node Scenarios
+
 ## [Unreleased][]
 
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.26.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Removed
+
+Removed method client.V1beta1Eviction()
+
 ### Updated
 
 -Updated Pod Eviction Method for Drain Node Scenarios

--- a/chaosk8s/node/actions.py
+++ b/chaosk8s/node/actions.py
@@ -338,7 +338,6 @@ def drain_nodes(
 
         logger.debug(f"Found {len(eviction_candidates)} pods to evict")
         for pod in eviction_candidates:
-            # eviction = client.V1beta1Eviction()
             eviction = client.V1Eviction()
             eviction.metadata = client.V1ObjectMeta()
             eviction.metadata.name = pod.metadata.name

--- a/chaosk8s/node/actions.py
+++ b/chaosk8s/node/actions.py
@@ -338,8 +338,8 @@ def drain_nodes(
 
         logger.debug(f"Found {len(eviction_candidates)} pods to evict")
         for pod in eviction_candidates:
-            eviction = client.V1beta1Eviction()
-
+            # eviction = client.V1beta1Eviction()
+            eviction = client.V1Eviction()
             eviction.metadata = client.V1ObjectMeta()
             eviction.metadata.name = pod.metadata.name
             eviction.metadata.namespace = pod.metadata.namespace


### PR DESCRIPTION
Removed V1beta1Eviction  since it was deprecated and is removed in Kubernetes 1.22.
Added  V1Eviction  for Drain Node Scenarios