### PR TITLE
action rollout deployment implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased][]
 
+### Added
+
+* Rollout deployment action `chaosk8s.deployment.actions.rollout_deployment`
+
 [Unreleased]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.26.4...HEAD
 
 

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -1,6 +1,6 @@
+import datetime
 import json
 import os.path
-import datetime
 
 import yaml
 from chaoslib.exceptions import ActivityFailed
@@ -15,7 +15,7 @@ __all__ = [
     "create_deployment",
     "delete_deployment",
     "scale_deployment",
-    "rollout_deployment"
+    "rollout_deployment",
 ]
 
 
@@ -105,13 +105,9 @@ def rollout_deployment(
     now = datetime.datetime.now(datetime.timezone.utc)
     now = str(now.isoformat("T") + "Z")
     body = {
-        'spec': {
-            'template': {
-                'metadata': {
-                    'annotations': {
-                        'kubectl.kubernetes.io/restartedAt': now
-                    }
-                }
+        "spec": {
+            "template": {
+                "metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": now}}
             }
         }
     }

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -1,5 +1,6 @@
 import json
 import os.path
+import datetime
 
 import yaml
 from chaoslib.exceptions import ActivityFailed
@@ -10,7 +11,12 @@ from logzero import logger
 
 from chaosk8s import create_k8s_api_client
 
-__all__ = ["create_deployment", "delete_deployment", "scale_deployment"]
+__all__ = [
+    "create_deployment",
+    "delete_deployment",
+    "scale_deployment",
+    "rollout_deployment"
+]
 
 
 def create_deployment(spec_path: str, ns: str = "default", secrets: Secrets = None):
@@ -81,4 +87,38 @@ def scale_deployment(
     except ApiException as e:
         raise ActivityFailed(
             f"failed to scale '{name}' to {replicas} replicas: {str(e)}"
+        )
+
+
+def rollout_deployment(
+    name: str = None,
+    ns: str = "default",
+    secrets: Secrets = None,
+):
+    """
+    Rolling the deployment. The `name` is the name of the deployment.
+    """
+    api = create_k8s_api_client(secrets)
+
+    v1 = client.AppsV1Api(api)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    now = str(now.isoformat("T") + "Z")
+    body = {
+        'spec': {
+            'template': {
+                'metadata': {
+                    'annotations': {
+                        'kubectl.kubernetes.io/restartedAt': now
+                    }
+                }
+            }
+        }
+    }
+
+    try:
+        v1.patch_namespaced_deployment(name=name, namespace=ns, body=body)
+    except ApiException as e:
+        raise ActivityFailed(
+            f"failed to rollout the deployment '{name}'! Error: {str(e)}"
         )

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,5 +1,5 @@
-from unittest.mock import ANY, MagicMock, call, patch
 from datetime import datetime, timezone
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 import urllib3
@@ -198,16 +198,16 @@ def test_rollout_deployment(client, api):
     client.AppsV1Api.return_value = v1
     mock_now = _generate_mock_time()
 
-    with patch('datetime.datetime') as mock_time:
+    with patch("datetime.datetime") as mock_time:
         mock_time.now.return_value = mock_now
         mock_now_str = f'{mock_now.isoformat("T")}Z'
 
         body = {
-            'spec': {
-                'template': {
-                    'metadata': {
-                        'annotations': {
-                            'kubectl.kubernetes.io/restartedAt': mock_now_str
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "kubectl.kubernetes.io/restartedAt": mock_now_str
                         }
                     }
                 }

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,4 +1,5 @@
 from unittest.mock import ANY, MagicMock, call, patch
+from datetime import datetime, timezone
 
 import pytest
 import urllib3
@@ -8,6 +9,7 @@ from kubernetes.client.models import V1Deployment, V1DeploymentList, V1ObjectMet
 from chaosk8s.deployment.actions import (
     create_deployment,
     delete_deployment,
+    rollout_deployment,
     scale_deployment,
 )
 from chaosk8s.deployment.probes import (
@@ -183,3 +185,37 @@ def test_deployment_is_not_fully_available_when_it_should(cl, client, watch, has
     with pytest.raises(ActivityFailed) as x:
         deployment_fully_available("mysvc")
     assert "deployment 'mysvc' failed to recover within" in str(x.value)
+
+
+def _generate_mock_time():
+    return datetime(2023, 6, 7, 10, 30, 0, tzinfo=timezone.utc)
+
+
+@patch("chaosk8s.deployment.actions.create_k8s_api_client", autospec=True)
+@patch("chaosk8s.deployment.actions.client", autospec=True)
+def test_rollout_deployment(client, api):
+    v1 = MagicMock()
+    client.AppsV1Api.return_value = v1
+    mock_now = _generate_mock_time()
+
+    with patch('datetime.datetime') as mock_time:
+        mock_time.now.return_value = mock_now
+        mock_now_str = f'{mock_now.isoformat("T")}Z'
+
+        body = {
+            'spec': {
+                'template': {
+                    'metadata': {
+                        'annotations': {
+                            'kubectl.kubernetes.io/restartedAt': mock_now_str
+                        }
+                    }
+                }
+            }
+        }
+
+        rollout_deployment("fake", "fake_ns")
+
+        v1.patch_namespaced_deployment.assert_called_with(
+            name="fake", namespace="fake_ns", body=body
+        )


### PR DESCRIPTION
Hello
This module is for rolling update deployments. I started to use today.
Ex.

```
method:
- type: action
  name: rollout deployment
  provider:
    type: python
    module: chaosk8s.deployment.actions
    func: rollout_deployment
    arguments:
      name: test
      ns: test
  pauses:
    after: 200
```

- [x] Rollout deployment.
- [x] Add unreleased comment to CHANGELOG.md
- [x] Run tests
- [x] Enjoy coding this beatiful framework !!!

Thanks.