### PR TITLE
fix(deployments): use yaml.safe_load()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Actions `chaosk8s.secret.actions.create_secret` and `chaosk8s.secret.actions.delete_secret`
 * Probes `chaosk8s.secret.probes.secret_exists`
 
+### Fixed
+
+* Use `yaml.safe_load()` in `chaosk8s.deployment.actions`
+
 ## [0.28.0][] - 2023-06-09
 
 [0.28.0]: https://github.com/chaostoolkit/chaostoolkit-kubernetes/compare/0.27.0...0.28.0

--- a/chaosk8s/deployment/actions.py
+++ b/chaosk8s/deployment/actions.py
@@ -31,7 +31,7 @@ def create_deployment(spec_path: str, ns: str = "default", secrets: Secrets = No
         if ext == ".json":
             deployment = json.loads(f.read())
         elif ext in [".yml", ".yaml"]:
-            deployment = yaml.load(f.read())
+            deployment = yaml.safe_load(f.read())
         else:
             raise ActivityFailed(f"cannot process {spec_path}")
 


### PR DESCRIPTION
Newer versions of the YAML library require the specification of a Loader class. As we don't need 'dangerous' features of YAML we are able to use safe_load() directly.