### PR TITLE
Ctk 285 - fix broken document linkin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ That's it! Notice how the action gives you the way to kill one pod randomly.
 
 Please explore the [documentation][doc] to see existing probes and actions.
 
-[doc]: https://docs.chaostoolkit.org/drivers/kubernetes/#exported-activities
+[doc]: https://chaostoolkit.org/drivers/kubernetes/#exported-activities
 
 ### Low level fault injections
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ $ export KUBECONFIG=/tmp/my-config
 
 #### Specify the Kubernetes context
 
-Quite often, your Kubernetes configuration contains several entries and you
-need to define the one to use as a default context when not it isn't
-explicitely provided.
+Quite often, your Kubernetes configuration contains several entries, and you
+need to define the one to use as a default context when it isn't
+explicitly provided.
 
 You may of course change your default using
 `kubectl config use-context KUBERNETES_CONTEXT` but you can also be explicit
@@ -182,7 +182,7 @@ env:
 
 ## Pass all credentials in the experiment
 
-Finally, you may pass explicitely all required credentials information to the
+Finally, you may pass explicitly all required credentials information to the
 experiment as follows:
 
 ### Using an API key
@@ -290,7 +290,7 @@ the dependencies.
 $ pdm install
 ```
 
-Now, you can edit the files and they will be automatically be seen by your
+Now, you can edit the files, and they will be automatically be seen by your
 environment, even when running from the `chaos` command locally.
 
 ### Tests


### PR DESCRIPTION
This [issue](https://github.com/chaostoolkit/chaostoolkit/issues/285) was raised on the CTK orchestrator project however the source of the docs I believe is the readme of this project.

I guess you will need to run a manual workflow on ctk-docs project to actually publish this. 